### PR TITLE
Fix DNS fallback and cert generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 /.idea
+__pycache__/
+mycert.crt
+mycert.key
+*.log
+*.tmp
+geoip.dat
+geosite.dat

--- a/Xray-config/MITM-DomainFronting.json
+++ b/Xray-config/MITM-DomainFronting.json
@@ -7,7 +7,7 @@
   },
 
 
-  "remarks": "MITM-DomainFronting_v22",
+  "remarks": "MITM-DomainFronting_v23",
 
   "version": {
     "min": "26.2.6"
@@ -30,7 +30,8 @@
     "hosts": {
       "geosite:category-ads-all": "#3",
 	  "fastly.redirect": "github.githubassets.com",
-      "dns.redirect": ["1.1.1.1", "1.0.0.1"]
+      "dns.cloudflare.redirect": ["1.1.1.1", "1.0.0.1"],
+      "dns.google.redirect": ["8.8.8.8", "8.8.4.4"]
     },
     "servers": [
       {
@@ -38,14 +39,18 @@
         "domains": ["domain:ir", "geosite:private", "geosite:category-ir", "full:github.githubassets.com"]
       },
       {
-        "tag": "no-filter-dns",
+        "tag": "no-filter-dns-cloudflare",
         "address": "h2c://1.1.1.1/dns-query",
-        "timeoutMs": 15000,
-        "finalQuery": true
+        "timeoutMs": 6000
+      },
+      {
+        "tag": "no-filter-dns-google",
+        "address": "h2c://8.8.8.8/dns-query",
+        "timeoutMs": 6000
       },
       {
         "address": "localhost",
-        "domains": ["domain:ir", "geosite:private", "geosite:category-ir", "full:github.githubassets.com"],
+        "timeoutMs": 4000,
         "finalQuery": true
       }
     ],
@@ -184,16 +189,41 @@
       }
     },
     {
-      "tag": "tls-repack-dns",
+      "tag": "tls-repack-dns-cloudflare",
       "protocol": "direct",
       "settings": {
-        "redirect": "dns.redirect:443"
+        "redirect": "dns.cloudflare.redirect:443"
       },
       "streamSettings": {
         "security": "tls",
         "tlsSettings": {
           "serverName": "www.microsoft.com",
-          "verifyPeerCertByName": "fromMitM,www.microsoft.com,www.google.com,dns.google,cloudflare-dns.com,one.one.one.one",
+          "verifyPeerCertByName": "fromMitM,www.microsoft.com,www.google.com,dns.google,cloudflare-dns.com,one.one.one.one,1.1.1.1,1.0.0.1",
+          "alpn": ["fromMitM"],
+          "fingerprint": "chrome"
+        },
+		"sockopt": {
+          "domainStrategy": "ForceIP",
+          "happyEyeballs": {
+            "tryDelayMs": 300,
+            "prioritizeIPv6": false,
+            "interleave": 2,
+            "maxConcurrentTry": 20
+          }
+        }
+      }
+    },
+    {
+      "tag": "tls-repack-dns-google",
+      "protocol": "direct",
+      "settings": {
+        "redirect": "dns.google.redirect:443"
+      },
+      "streamSettings": {
+        "security": "tls",
+        "tlsSettings": {
+          "serverName": "www.google.com",
+          "verifyPeerCertByName": "fromMitM,www.google.com,dns.google,8.8.8.8,8.8.4.4",
           "alpn": ["fromMitM"],
           "fingerprint": "chrome"
         },
@@ -287,8 +317,12 @@
        "domain": ["geosite:category-ads-all"]
       },
       {
-	   "outboundTag": "tls-repack-dns",
-       "inboundTag": ["no-filter-dns"]
+	   "outboundTag": "tls-repack-dns-cloudflare",
+       "inboundTag": ["no-filter-dns-cloudflare"]
+      },
+      {
+	   "outboundTag": "tls-repack-dns-google",
+       "inboundTag": ["no-filter-dns-google"]
       },
       {
 	   "outboundTag": "dns-out",

--- a/Xray-config/certificate_generator.bat
+++ b/Xray-config/certificate_generator.bat
@@ -1,3 +1,69 @@
 @echo off
-xray\xray.exe tls cert -ca -file=mycert
+setlocal EnableExtensions
+
+set "SCRIPT_DIR=%~dp0"
+cd /d "%SCRIPT_DIR%" || (
+  echo Could not enter script directory.
+  pause
+  exit /b 1
+)
+
+set "XRAY_BIN="
+if exist "%SCRIPT_DIR%xray\xray.exe" set "XRAY_BIN=%SCRIPT_DIR%xray\xray.exe"
+if not defined XRAY_BIN if exist "%SCRIPT_DIR%xray.exe" set "XRAY_BIN=%SCRIPT_DIR%xray.exe"
+if not defined XRAY_BIN for %%X in (xray.exe) do if not defined XRAY_BIN set "XRAY_BIN=%%~$PATH:X"
+
+if not defined XRAY_BIN (
+  echo xray.exe was not found.
+  echo Put this file in the v2rayN bin folder, or add xray.exe to PATH.
+  pause
+  exit /b 1
+)
+
+set "OUT_DIR=%CD%"
+set "WRITE_TEST=%OUT_DIR%\.mitm-write-test.tmp"
+> "%WRITE_TEST%" echo test 2>nul
+if errorlevel 1 (
+  set "OUT_DIR=%USERPROFILE%\Desktop\MITM-DomainFronting-cert"
+) else (
+  del "%WRITE_TEST%" >nul 2>nul
+)
+
+if not exist "%OUT_DIR%" mkdir "%OUT_DIR%" >nul 2>nul
+if not exist "%OUT_DIR%" (
+  echo Could not create output folder:
+  echo %OUT_DIR%
+  pause
+  exit /b 1
+)
+
+set "TMP_JSON=%TEMP%\mitm-domainfronting-cert-%RANDOM%.json"
+"%XRAY_BIN%" tls cert -ca > "%TMP_JSON%"
+if errorlevel 1 (
+  echo xray failed to generate the certificate.
+  if exist "%TMP_JSON%" type "%TMP_JSON%"
+  pause
+  exit /b 1
+)
+
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$ErrorActionPreference='Stop'; $j=Get-Content -Raw -Path $env:TMP_JSON | ConvertFrom-Json; [IO.File]::WriteAllText((Join-Path $env:OUT_DIR 'mycert.crt'), (($j.certificate -join [Environment]::NewLine) + [Environment]::NewLine)); [IO.File]::WriteAllText((Join-Path $env:OUT_DIR 'mycert.key'), (($j.key -join [Environment]::NewLine) + [Environment]::NewLine))"
+if errorlevel 1 (
+  echo Could not parse xray certificate output.
+  if exist "%TMP_JSON%" type "%TMP_JSON%"
+  pause
+  exit /b 1
+)
+
+del "%TMP_JSON%" >nul 2>nul
+
+echo Created:
+echo   %OUT_DIR%\mycert.crt
+echo   %OUT_DIR%\mycert.key
+echo.
+echo Keep mycert.key private. Do not send it to anyone.
+if /I not "%OUT_DIR%"=="%CD%" (
+  echo.
+  echo The current folder was not writable, so the files were written to Desktop.
+  echo Copy both files next to this Xray config before running MITM-DomainFronting.
+)
 pause

--- a/Xray-config/certificate_generator.sh
+++ b/Xray-config/certificate_generator.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env sh
+set -eu
+
+out_dir="."
+if [ "${1:-}" = "--out-dir" ]; then
+  out_dir="${2:-}"
+fi
+
+if [ -z "$out_dir" ]; then
+  echo "Usage: certificate_generator.sh [--out-dir DIR]" >&2
+  exit 2
+fi
+
+find_xray() {
+  if [ -n "${XRAY_BIN:-}" ] && [ -x "$XRAY_BIN" ]; then
+    printf '%s\n' "$XRAY_BIN"
+    return
+  fi
+  if command -v xray >/dev/null 2>&1; then
+    command -v xray
+    return
+  fi
+  for x in ./xray ./xray/xray /Applications/v2rayN.app/Contents/MacOS/bin/xray/xray; do
+    if [ -x "$x" ]; then
+      printf '%s\n' "$x"
+      return
+    fi
+  done
+  return 1
+}
+
+xray_bin="$(find_xray || true)"
+if [ -z "$xray_bin" ]; then
+  echo "xray not found; set XRAY_BIN=/path/to/xray" >&2
+  exit 1
+fi
+
+mkdir -p "$out_dir"
+tmp_json="$(mktemp "${TMPDIR:-/tmp}/mitm-domainfronting-cert.XXXXXX.json")"
+trap 'rm -f "$tmp_json"' EXIT
+
+"$xray_bin" tls cert -ca >"$tmp_json"
+
+if command -v jq >/dev/null 2>&1; then
+  jq -r '.certificate[]' "$tmp_json" >"$out_dir/mycert.crt"
+  jq -r '.key[]' "$tmp_json" >"$out_dir/mycert.key"
+else
+  python3 - "$tmp_json" "$out_dir" <<'PY'
+import json
+import pathlib
+import sys
+
+j = json.loads(pathlib.Path(sys.argv[1]).read_text())
+out = pathlib.Path(sys.argv[2])
+(out / "mycert.crt").write_text("\n".join(j["certificate"]) + "\n")
+(out / "mycert.key").write_text("\n".join(j["key"]) + "\n")
+PY
+fi
+
+chmod 644 "$out_dir/mycert.crt"
+chmod 600 "$out_dir/mycert.key"
+echo "created $out_dir/mycert.crt and $out_dir/mycert.key"


### PR DESCRIPTION
Fix DNS fallback when Cloudflare DoH times out.
Add Google DoH repack route.
Make Windows certificate generator handle unwritable folders.
Add macOS/Linux certificate generator.

Tested: jq, sh -n, cert generation, xray run -test.